### PR TITLE
Fix seg fault

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -80,16 +80,16 @@ void receive_handshake_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 
 u32 send_handshake(void)
 {
-  struct __attribute__((packed)) {
-    u32 flags;
-    char version[strlen(git_commit)];
-  } handshake;
-  u8 buflen = sizeof(handshake) + 1;
+  msg_bootloader_handshake_response_t *handshake;
+  u32 flags = SBP_MAJOR_VERSION << 8 | SBP_MINOR_VERSION;
+  u8 buflen = sizeof(*handshake) + strlen(git_commit)+1;
+  u8 buf[buflen];
 
-  handshake.flags = SBP_MAJOR_VERSION << 8 | SBP_MINOR_VERSION;
-  strncpy(handshake.version, git_commit, strlen(git_commit)+1);
+  handshake = (msg_bootloader_handshake_response_t *)buf;
+  handshake->flags = flags;
+  strncpy(handshake->version, git_commit, strlen(git_commit)+1);
 
-  return sbp_send_msg(SBP_MSG_BOOTLOADER_HANDSHAKE_RESPONSE, buflen, (u8 *)&handshake);
+  return sbp_send_msg(SBP_MSG_BOOTLOADER_HANDSHAKE_RESPONSE, buflen, buf);
 }
 
 int main(void)

--- a/src/main.c
+++ b/src/main.c
@@ -80,11 +80,13 @@ void receive_handshake_callback(u16 sender_id, u8 len, u8 msg[], void* context)
 
 u32 send_handshake(void)
 {
-  msg_bootloader_handshake_response_t handshake;
-  u32 flags = SBP_MAJOR_VERSION << 8 | SBP_MINOR_VERSION;
-  u8 buflen = sizeof(handshake) + strlen(git_commit)+1;
+  struct __attribute__((packed)) {
+    u32 flags;
+    char version[strlen(git_commit)];
+  } handshake;
+  u8 buflen = sizeof(handshake) + 1;
 
-  handshake.flags = flags;
+  handshake.flags = SBP_MAJOR_VERSION << 8 | SBP_MINOR_VERSION;
   strncpy(handshake.version, git_commit, strlen(git_commit)+1);
 
   return sbp_send_msg(SBP_MSG_BOOTLOADER_HANDSHAKE_RESPONSE, buflen, (u8 *)&handshake);

--- a/stm32/Makefile.include
+++ b/stm32/Makefile.include
@@ -16,7 +16,7 @@
 
 SWIFTNAV_ROOT ?= ..
 PREFIX ?= arm-none-eabi
-GIT_COMMIT := $(shell git describe --dirty --tags --always)
+GIT_COMMIT := $(shell git describe --dirty --tags --always | xargs echo -n)
 # PREFIX ?= arm-elf
 CC = $(PREFIX)-gcc
 LD = $(PREFIX)-gcc


### PR DESCRIPTION
git commit was overflowing char version[0] and causing a seg fault. Not sure if there's a way to use the struct defined in libsbp?

This now passes the bootloader integration test suite in https://github.com/swift-nav/piksi_tools/blob/bootloader-tests-rebase/tests/test_bootloader.py.

/cc @mfine @fnoble 
